### PR TITLE
added and test colorscheme definition in tailwind

### DIFF
--- a/frontend/app.json
+++ b/frontend/app.json
@@ -38,7 +38,8 @@
             "backgroundColor": "#000000"
           }
         }
-      ]
+      ],
+      "expo-font"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/frontend/app/(tabs)/explore.tsx
+++ b/frontend/app/(tabs)/explore.tsx
@@ -1,11 +1,15 @@
-import { View, Text } from 'react-native';
+import React from 'react';
+import { View, Text, TouchableOpacity } from 'react-native';
 
 import { Link } from 'expo-router';
 
 export default function ExploreScreen() {
   return (
-    <View className='flex-1 flex-col justify-center items-center'>
-      <Text className='text-3xl'>This is the for you page.</Text>
+    <View className='bg-background flex-1 flex-col justify-center items-center'>
+      <Text className='text-3xl text-foreground font-bold'>This is the for you page.</Text>
+      <TouchableOpacity className='bg-accent p-3 rounded-full mt-20' onPress={() => console.log("hi")}>
+        <Text className='text-white'>This is a button.</Text>
+      </TouchableOpacity>
     </View>
   );
 }

--- a/frontend/app/_layout.tsx
+++ b/frontend/app/_layout.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
@@ -5,7 +6,7 @@ import { StatusBar } from 'expo-status-bar';
 
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
-import '../global.css';
+import '@/global.css';
 
 export const unstable_settings = {
   anchor: '(tabs)',

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,7 +4,14 @@ module.exports = {
   content: ["./App.tsx", "./components/**/*.{js,jsx,ts,tsx}", "./app/**/*.{js,jsx,ts,tsx}"],
   presets: [require("nativewind/preset")],
   theme: {
-    extend: {},
+    extend: {
+      colors: {
+        background: '#FFF0E2',
+        foreground: '#411900',
+        accent: '#AE6E4E',
+        secondary: '#F6D0AE',
+      }
+    },
   },
   plugins: [],
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": [ "nativewind/types" ],
     "paths": {
       "@/*": [
         "./*"


### PR DESCRIPTION
### Description of Changes
- Defined colourscheme in tailwind.config.js using colours from figma design
- Added NativeWind Typescript support via nativewind-env.d.ts
- Updated tsconfig.json to include NativeWind types
- Created test screen to verify color implementation

### Screenshots (For UI Changes)
<img width="461" height="965" alt="Screenshot 2025-10-29 at 12 39 55 AM" src="https://github.com/user-attachments/assets/ab3f919f-27ff-4773-908e-086853c9b892" />

### Additional Comments (Optional)
- Color palette includes foreground, background, accent and secondary colours as defined in the figma mockup
- Colors can now be used with Tailwind utilities: `bg-background`, `text-foreground`, `bg-accent`, `border-secondary`