### PR TITLE
Urgent: Prevent Invalid Email Creation in auth.users

### DIFF
--- a/backend/src/__tests__/jwt-auth.test.ts
+++ b/backend/src/__tests__/jwt-auth.test.ts
@@ -16,7 +16,9 @@ const TEST_USER_PASSWORD = "testpassword123";
 
 const TEST_EVENT_ID = "2430b29f-0bd3-4d49-9b70-9c8a0b26bf8e"; // "Test Event"
 
-describe("JWT Authentication", () => {
+// URGENT: tests temporarily skipped to prevent creating users with invalid emails
+// TODO: re-enable after email validation is implemented
+describe.skip("JWT Authentication", () => {
     let jwtToken: string;
     let supabase: ReturnType<typeof createClient>;
 
@@ -167,7 +169,9 @@ describe("JWT Authentication", () => {
     });
 });
 
-describe("Sign-In Business Logic", () => {
+// URGENT: tests temporarily skipped to prevent creating users with invalid emails
+// TODO: re-enable after email validation is implemented
+describe.skip("Sign-In Business Logic", () => {
     // test sign-in using db layer methods
     
     // 1. test sign-in with valid credentials

--- a/backend/src/db/supabaseClient.ts
+++ b/backend/src/db/supabaseClient.ts
@@ -467,6 +467,10 @@ export const db = {
             }).select().single(),
     },
     healthCheck: () => supabase.from("venues").select("count").limit(1), // returns the number of venues
+
+    // URGENT: auth methods are temporarily disabled to prevent creating users with invalid emails
+    // TODO: re-enable after email validation is implemented
+    /*
     auth: {
         // validate JWT token with Supabase Auth
         validateJWT: (token: string) => supabase.auth.getUser(token),
@@ -482,4 +486,5 @@ export const db = {
         // sign out user (optional, for future use)
         signOut: () => supabase.auth.signOut(),
     },
+    */
 };


### PR DESCRIPTION
## Problem
Supabase detected high rate of bounced emails due to invalid email addresses (`@example.com`, `@test.com`) being inserted into `auth.users`, which triggers automatic verification emails.

## Solution
- **Disabled test file** (`jwt-auth.test.ts`) that uses `test_auth@example.com` - tests are skipped to prevent any auth user creation
- **Disabled databse method** (`db.auth` in `supabaseClients.ts`)
- See commit 55b45f7

## Key Insight
- `public.users` is our custom table, so no email will be sent from Supabase
- `auth.users` is Supabase-managed, so it triggers emails and must be protected
- Currently no code paths call `db.auth.signUp()` (the only way to create `auth.users` records)

## Future Work
When implementing registration/auth endpoints that use `db.auth.signUp()`, add email validation to reject invalid email patterns before calling `signUp()`.
